### PR TITLE
BITMAKER-1133: Add environment variables to spiders

### DIFF
--- a/bm_cli/bm_client.py
+++ b/bm_cli/bm_client.py
@@ -143,9 +143,16 @@ class BmClient(BmSimpleClient):
         self.check_status(response, 200)
         return response.json()
 
-    def create_spider_job(self, pid, sid, job_type="", args=[], schedule=""):
+    def create_spider_job(
+        self, pid, sid, job_type="", args=[], env_vars=[], schedule=""
+    ):
         endpoint = "projects/{}/spiders/{}/jobs".format(pid, sid)
-        data = {"job_type": job_type, "args": args, "schedule": schedule}
+        data = {
+            "job_type": job_type,
+            "args": args,
+            "env_vars": env_vars,
+            "schedule": schedule,
+        }
         response = self.post(endpoint, data=data)
         self.check_status(response, 201)
         return response.json()

--- a/bm_cli/create/job.py
+++ b/bm_cli/create/job.py
@@ -7,13 +7,13 @@ from bm_cli.utils import get_bm_settings
 SHORT_HELP = "Create a new job"
 
 
-def validate_arg(ctx, param, value):
+def validate_key_value_format(ctx, param, value):
     try:
-        args = []
+        key_val_pairs = []
         for pair in value:
             key, val = pair.split("=", 1)
-            args.append({"name": key, "value": val})
-        return args
+            key_val_pairs.append({"name": key, "value": val})
+        return key_val_pairs
     except:
         raise click.BadParameter("format must be 'NAME=VALUE'")
 
@@ -26,10 +26,18 @@ def validate_arg(ctx, param, value):
     "-a",
     multiple=True,
     type=click.UNPROCESSED,
-    callback=validate_arg,
+    callback=validate_key_value_format,
     help="Set spider job argument NAME=VALUE (may be repeated)",
 )
-def bm_command(sid, pid, arg):
+@click.option(
+    "--env",
+    "-e",
+    multiple=True,
+    type=click.UNPROCESSED,
+    callback=validate_key_value_format,
+    help="Set spider job environment variable NAME=VALUE (may be repeated)",
+)
+def bm_command(sid, pid, arg, env):
     """Create a new job
 
     \b
@@ -47,7 +55,7 @@ def bm_command(sid, pid, arg):
                 "No active project in the current directory. Please specify the PID."
             )
     try:
-        response = bm_client.create_spider_job(pid, sid, "SINGLE_JOB", arg)
+        response = bm_client.create_spider_job(pid, sid, "SINGLE_JOB", arg, env)
         click.echo("job/{} created.".format(response["name"]))
     except Exception as ex:
         raise click.ClickException("Cannot create the job for given SID and PID.")

--- a/bm_cli/create/job.py
+++ b/bm_cli/create/job.py
@@ -9,11 +9,11 @@ SHORT_HELP = "Create a new job"
 
 def validate_key_value_format(ctx, param, value):
     try:
-        key_val_pairs = []
+        key_value_pairs = []
         for pair in value:
-            key, val = pair.split("=", 1)
-            key_val_pairs.append({"name": key, "value": val})
-        return key_val_pairs
+            key, value = pair.split("=", 1)
+            key_value_pairs.append({"name": key, "value": value})
+        return key_value_pairs
     except:
         raise click.BadParameter("format must be 'NAME=VALUE'")
 

--- a/bm_cli/list/job.py
+++ b/bm_cli/list/job.py
@@ -2,7 +2,7 @@ import click
 
 from tabulate import tabulate
 from bm_cli.login import login
-from bm_cli.utils import get_bm_settings, format_time, format_args
+from bm_cli.utils import get_bm_settings, format_time, format_key_value_pairs
 
 SHORT_HELP = "List the spider's jobs"
 
@@ -41,12 +41,13 @@ def bm_command(sid, pid):
         [
             job["jid"],
             job["job_status"].capitalize(),
-            format_args(job["args"]),
+            format_key_value_pairs(job["args"]),
+            format_key_value_pairs(job["env_vars"]),
             format_time(job["created"]),
         ]
         for job in jobs
         if job["job_type"] == "SINGLE_JOB"
     ]
 
-    headers = ["JID", "STATUS", "ARGS", "CREATED"]
+    headers = ["JID", "STATUS", "ARGS", "ENV VARS", "CREATED"]
     click.echo(tabulate(jobs, headers, numalign="left", tablefmt="plain"))

--- a/bm_cli/utils.py
+++ b/bm_cli/utils.py
@@ -69,13 +69,13 @@ def format_time(date):
     return date.strftime("%Y-%m-%d %H:%M")
 
 
-def format_args(args):
-    if not args:
+def format_key_value_pairs(key_value_pairs):
+    if not key_value_pairs:
         return ""
 
     result = ""
-    for arg in args[:-1]:
-        result += "{}: {}\n".format(arg["name"], arg["value"])
+    for key_value in key_value_pairs[:-1]:
+        result += "{}: {}\n".format(key_value["name"], key_value["value"])
 
-    result += "{}: {}".format(args[-1]["name"], args[-1]["value"])
+    result += "{}: {}".format(key_value_pairs[-1]["name"], key_value_pairs[-1]["value"])
     return result

--- a/tests.py
+++ b/tests.py
@@ -121,6 +121,7 @@ class TestBMClient(unittest.TestCase):
         self.assertIn("jid", job)
         self.assertIn("name", job)
         self.assertIn("args", job)
+        self.assertIn("env_vars", job)
         self.assertIn("job_type", job)
         self.assertIn("schedule", job)
         self.assertEqual(job["job_status"], "WAITING")


### PR DESCRIPTION
Ticket URL:

- http://tasks.bitmaker.la/issues/1133

Description:

- Added passing of environment variables as an option for `bitmaker create job`. Environment variables can now be added in the same fashion as arguments using `-e` or `--env`.