### PR TITLE
BITMAKER-1136: update default host

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Bitmaker Scraping Product CLI
+# Bitmaker Cloud CLI
 
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 

--- a/bm_cli/login.py
+++ b/bm_cli/login.py
@@ -15,7 +15,7 @@ from bm_cli.utils import (
 from bm_cli.templates import BITMAKER_AUTH_NAME, BITMAKER_AUTH
 
 
-DEFAULT_BM_API_HOST = "http://178.128.134.208:8000"
+DEFAULT_BM_API_HOST = "http://178.128.134.208"
 
 
 SHORT_HELP = "Save your credentials"


### PR DESCRIPTION
Ticket URL:

- http://tasks.bitmaker.la/issues/1136

Description:

- Update default bitmaker host.