### PR TITLE
BITMAKER-1261: Improve Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
-# Bitmaker Cloud CLI
+<h1 align="center"> Bitmaker Cloud CLI </h1>
 
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+
+Bitmaker Cloud CLI is the command line client to interact with Bitmaker Cloud API. Allows the user to perform the following actions:
+- Link a Scrapy project with a project in Bitmaker Cloud.
+- Create projects, jobs and cronjobs in Bitmaker Cloud.
+- Get the data of a job.
 
 ```bash
 $ bitmaker
@@ -9,17 +14,25 @@ Usage: bitmaker [OPTIONS] COMMAND [ARGS]...
 Options:
   --version   Show the version and exit.
   -h, --help  Show this message and exit.
+  -l, --local When init a project, indicate that you use local-registry       
 
 Commands:
   context  Show your current context
   create   Create a resource
   delete   Delete a resource
   deploy   Deploy Scrapy project to Bitmaker Cloud
+  data     Returns all the data of a job and saves it in a json file
   init     Initialize bitmaker project for existing scrapy project
   list     Display the available resources
   login    Save your credentials
   logout   Remove your credentials
   stop     Stop an active job or cronjob
+
+Args:
+  project  All projects or a project if it is followed by the ID of that project
+  spider   All the spiders or a spider if it is followed by the ID of that spider
+  job      All jobs or a job if the ID of that job follows
+  cronjob  All cronjobs or a cronjob if it is followed by the ID of that cronjob 
 ```
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Bitmaker Cloud CLI is the command line client to interact with Bitmaker Cloud API. Allows the user to perform the following actions:
 - Link a Scrapy project with a project in Bitmaker Cloud.
-- Create projects, jobs and cronjobs in Bitmaker Cloud.
+- Create projects and jobs in Bitmaker Cloud.
 - Get the data of a job.
 
 ```bash

--- a/bm_cli/__main__.py
+++ b/bm_cli/__main__.py
@@ -23,6 +23,7 @@ commands = [
     "logout",
     "init",
     "context",
+    "data",
 ]
 
 for command in commands:

--- a/bm_cli/bm_client.py
+++ b/bm_cli/bm_client.py
@@ -137,8 +137,19 @@ class BmClient(BmSimpleClient):
         response = self.get(endpoint, paginated=True)
         return response
 
+    def get_spider_jobs_with_tag(self, pid, sid, tag):
+        endpoint = "projects/{}/spiders/{}/jobs?tag={}".format(pid, sid, tag)
+        response = self.get(endpoint, paginated=True)
+        return response
+
     def get_spider_job(self, pid, sid, jid):
         endpoint = "projects/{}/spiders/{}/jobs/{}".format(pid, sid, jid)
+        response = self.get(endpoint)
+        self.check_status(response, 200)
+        return response.json()
+    
+    def get_spider_job_data(self, pid, sid, jid):
+        endpoint = "projects/{}/spiders/{}/jobs/{}/data?mode=all".format(pid, sid, jid)
         response = self.get(endpoint)
         self.check_status(response, 200)
         return response.json()

--- a/bm_cli/data/__init__.py
+++ b/bm_cli/data/__init__.py
@@ -1,0 +1,16 @@
+import click
+import importlib
+
+
+@click.group(short_help="Get data")
+def bm_command():
+    pass
+
+
+commands = [
+    "job",
+]
+
+for command in commands:
+    module = importlib.import_module("bm_cli.data.{}".format(command))
+    bm_command.add_command(module.bm_command, command)

--- a/bm_cli/data/job.py
+++ b/bm_cli/data/job.py
@@ -1,0 +1,37 @@
+import click
+
+from bm_cli.login import login
+from bm_cli.utils import get_bm_settings, get_project_path, save_data
+from bm_cli.templates import OK_EMOJI, BAD_EMOJI
+
+SHORT_HELP = "Get data from a job"
+
+@click.command(short_help=SHORT_HELP)
+@click.argument("jid", required=True)
+@click.argument("sid", required=True)
+@click.argument("pid", required=False)
+def bm_command(jid, sid, pid, ):
+    """Get data from a job
+
+    \b
+    SID is the spider's sid
+    PID is the project's pid (active project by default)
+    JID is the job's id
+    """
+
+    bm_client = login()
+    if pid is None:
+        try:
+            bm_settings = get_bm_settings()
+            pid = bm_settings["project"]["pid"]
+        except:
+            raise click.ClickException(
+                "No active project in the current directory. Please specify the PID."
+            )
+    try:
+        response = bm_client.get_spider_job_data(pid, sid, jid)
+        click.echo("{} Data retrieve succesfully.".format(OK_EMOJI))
+    except Exception as ex:
+        raise click.ClickException("{} Cannot get data".format(BAD_EMOJI))
+    save_data("{}-{}.json".format(jid,pid), response)
+    click.echo("{} Data saved succesfully.".format(OK_EMOJI))

--- a/bm_cli/list/job.py
+++ b/bm_cli/list/job.py
@@ -2,7 +2,7 @@ import click
 
 from tabulate import tabulate
 from bm_cli.login import login
-from bm_cli.utils import get_bm_settings, format_time, format_key_value_pairs
+from bm_cli.utils import get_bm_settings, format_time, format_key_value_pairs, format_tags
 
 SHORT_HELP = "List the spider's jobs"
 
@@ -10,12 +10,19 @@ SHORT_HELP = "List the spider's jobs"
 @click.command(short_help=SHORT_HELP)
 @click.argument("sid", required=True)
 @click.argument("pid", required=False)
-def bm_command(sid, pid):
+@click.option(
+    "-t",
+    "--tag",
+    type=click.UNPROCESSED,
+    help="Filter jobs by tag",
+)
+def bm_command(sid, pid, tag):
     """List jobs of a given spider
 
     \b
     SID is the spider's sid
     PID is the project's pid (active project by default)
+    TAG is tags to filter jobs
     """
 
     bm_client = login()
@@ -36,18 +43,23 @@ def bm_command(sid, pid):
             "The spider does not exist, or you do not have permission to perform this action."
         )
 
-    jobs = bm_client.get_spider_jobs(pid, sid)
+    jobs = []
+    if tag:
+        jobs = bm_client.get_spider_jobs_with_tag(pid, sid, tag)
+    else:
+        jobs = bm_client.get_spider_jobs(pid, sid)
+
     jobs = [
         [
             job["jid"],
             job["job_status"].capitalize(),
+            format_tags(job["tags"]),
             format_key_value_pairs(job["args"]),
             format_key_value_pairs(job["env_vars"]),
             format_time(job["created"]),
         ]
         for job in jobs
-        if job["job_type"] == "SINGLE_JOB"
     ]
 
-    headers = ["JID", "STATUS", "ARGS", "ENV VARS", "CREATED"]
+    headers = ["JID", "STATUS", "TAGS", "ARGS", "ENV VARS", "CREATED"]
     click.echo(tabulate(jobs, headers, numalign="left", tablefmt="plain"))

--- a/bm_cli/templates.py
+++ b/bm_cli/templates.py
@@ -12,6 +12,8 @@ host: $bm_host
 
 BITMAKER_DIR = ".bitmaker"
 
+DATA_DIR = "project_data"
+
 DOCKER_APP_DIR = "/usr/src/app"
 
 DOCKER_DEFAULT_REQUIREMENTS = "requirements.txt"

--- a/bm_cli/utils.py
+++ b/bm_cli/utils.py
@@ -1,11 +1,13 @@
 import os
 import yaml
+import json
 
 from datetime import datetime
 from bm_cli.templates import (
     BITMAKER_AUTH_NAME,
     BITMAKER_YAML_NAME,
     BITMAKER_DIR,
+    DATA_DIR,
     DOCKERFILE_NAME,
     LOCALHOST,
 )
@@ -81,6 +83,25 @@ def format_key_value_pairs(key_value_pairs):
     result += "{}: {}".format(key_value_pairs[-1]["name"], key_value_pairs[-1]["value"])
     return result
 
+def format_tags(tags):
+    if not tags:
+        return ""
+    result = ""
+    for tag in tags[:-1]:
+        result += "{}\n".format(tag["name"])
+    result += "{}".format(tags[-1]["name"])
+    return result
+
 def set_localhost(container_image):
     host,image = container_image.split("/")
     return "{}/{}".format(LOCALHOST,image)
+
+def save_data(filename, data):
+    project_path = get_project_path()
+    if not os.path.exists(DATA_DIR):
+        os.makedirs(DATA_DIR)
+    filename = os.path.join(project_path, DATA_DIR, filename)
+    with open(filename, 'w', encoding='utf-8') as F:
+        json.dump(data, F, ensure_ascii=False, indent=4)
+        
+


### PR DESCRIPTION
#### Ticket url:
- http://tasks.bitmaker.la/issues/1261

#### Description:
- Improve Readme, also modified commands to get data all from job and filter jobs for tag. Now we can get data with
`bitmaker data job <jobID> <spiderID> <projectID>`
The job data is saved in a folder called projects_path in json format. This folder is created in the path relative to where the terminal is.
- We can get jobs filter by tag
`bitmaker list job <spiderID> -t <tag>`
Tag is optional.
#### Checklist:
- [X] Rebase my branch