### PR TITLE
BITMAKER-1574: Raise error when a deploy project

### DIFF
--- a/bm_cli/deploy.py
+++ b/bm_cli/deploy.py
@@ -84,9 +84,8 @@ def bm_command():
     try:
         response = bm_client.upload_project(pid, open("{}.zip".format(pid), "rb"))
     except:
-        click.ClickException("A problem occurred while uploading the project.")
         os.remove("{}.zip".format(pid))
-        return
+        raise click.ClickException("A problem occurred while uploading the project.")
 
     click.echo(
         "{} Project uploaded successfully. Deploy {} underway.".format(


### PR DESCRIPTION
### Ticket URL:
- https://tasks.bitmaker.dev/issues/1574

### Description:
- When developing ticket 1574, the error indicating if a project was not uploaded successfully was not working. This happened because the error was not set to raise.