### PR TITLE
BITMAKER-1769: Improve Bitmaker CLI messages and fix typos

### DIFF
--- a/bm_cli/create/cronjob.py
+++ b/bm_cli/create/cronjob.py
@@ -17,7 +17,7 @@ SHORT_HELP = "Create a new cronjob"
     multiple=True,
     type=click.UNPROCESSED,
     callback=validate_key_value_format,
-    help="Set spider job argument NAME=VALUE (may be repeated)",
+    help="Set spider cronjob argument NAME=VALUE (may be repeated)",
 )
 @click.option(
     "--env",
@@ -25,7 +25,7 @@ SHORT_HELP = "Create a new cronjob"
     multiple=True,
     type=click.UNPROCESSED,
     callback=validate_key_value_format,
-    help="Set spider job environment variable NAME=VALUE (may be repeated)",
+    help="Set spider cronjob environment variable NAME=VALUE (may be repeated)",
 )
 @click.option(
     "--tag",

--- a/bm_cli/create/job.py
+++ b/bm_cli/create/job.py
@@ -32,7 +32,7 @@ SHORT_HELP = "Create a new job"
     multiple=True,
     type=click.UNPROCESSED,
     callback=set_tag_format,
-    help="Set spider cronjob tag (may have multiple)",
+    help="Set spider job tag (may have multiple)",
 )
 def bm_command(sid, pid, arg, env, tag):
     """Create a new job

--- a/bm_cli/data/job.py
+++ b/bm_cli/data/job.py
@@ -46,7 +46,7 @@ def bm_command(
             )
     try:
         response = bm_client.get_spider_job_data(pid, sid, jid, format)
-        click.echo("{} Data retrieve succesfully.".format(OK_EMOJI))
+        click.echo("{} Data retrieved succesfully.".format(OK_EMOJI))
     except Exception as ex:
         raise click.ClickException("{} Cannot get data".format(BAD_EMOJI))
     save_data("{}-{}.{}".format(jid, pid, format), response)

--- a/bm_cli/init.py
+++ b/bm_cli/init.py
@@ -95,7 +95,6 @@ def bm_command(pid, requirements):
     """Initialize bitmaker project
 
     PID is the project's pid
-    LOCAL is a flag that indicate if the registry host is local
     """
 
     if not os.path.exists(BITMAKER_DIR):

--- a/bm_cli/list/cronjob.py
+++ b/bm_cli/list/cronjob.py
@@ -9,7 +9,7 @@ from bm_cli.utils import (
     format_tags,
 )
 
-SHORT_HELP = "List the spider's cronjobs"
+SHORT_HELP = "List cronjobs of a given spider"
 
 
 @click.command(short_help=SHORT_HELP)

--- a/bm_cli/list/job.py
+++ b/bm_cli/list/job.py
@@ -9,7 +9,7 @@ from bm_cli.utils import (
     format_tags,
 )
 
-SHORT_HELP = "List the spider's jobs"
+SHORT_HELP = "List jobs of a given spider"
 
 
 @click.command(short_help=SHORT_HELP)

--- a/bm_cli/list/project.py
+++ b/bm_cli/list/project.py
@@ -4,7 +4,7 @@ from tabulate import tabulate
 from bm_cli.login import login
 
 
-SHORT_HELP = "List the user's projects"
+SHORT_HELP = "List the current user's projects"
 
 
 @click.command(short_help=SHORT_HELP)

--- a/bm_cli/list/spider.py
+++ b/bm_cli/list/spider.py
@@ -5,7 +5,7 @@ from bm_cli.login import login
 from bm_cli.utils import get_bm_settings
 
 
-SHORT_HELP = "List the project's spiders"
+SHORT_HELP = "List a project's spiders"
 
 
 @click.command(short_help=SHORT_HELP)

--- a/bm_cli/login.py
+++ b/bm_cli/login.py
@@ -14,7 +14,7 @@ from bm_cli.utils import (
 from bm_cli.templates import BITMAKER_AUTH_NAME, BITMAKER_AUTH
 
 
-DEFAULT_BM_API_HOST = "http://178.128.134.208"
+DEFAULT_BM_API_HOST = "http://localhost"
 
 
 SHORT_HELP = "Save your credentials"

--- a/bm_cli/update/cronjob.py
+++ b/bm_cli/update/cronjob.py
@@ -3,7 +3,7 @@ import click
 from bm_cli.login import login
 from bm_cli.utils import get_bm_settings
 
-SHORT_HELP = "Stop an active job"
+SHORT_HELP = "Update a cronjob"
 VALID_STATUSES = ["ACTIVE", "DISABLED"]
 
 


### PR DESCRIPTION
### Ticket URL:
- https://tasks.bitmaker.dev/issues/1769

### Description:
- Fixed some typos and erroneous messages (e.g., `"cronjob"` where it should say `"job"`)