### PR TITLE
Fix pagination bug and add page option to list job

### DIFF
--- a/estela_cli/estela_client.py
+++ b/estela_cli/estela_client.py
@@ -64,10 +64,19 @@ class EstelaSimpleClient:
             headers=headers,
         )
 
-    def get(self, endpoint, params=None, paginated=False):
+    def get(self, endpoint, params=None, paginated=False, page=None):
         if params is None:
             params = {}
         headers = self.get_default_headers()
+
+        if paginated and page is not None:
+            params["page"] = page
+            response = requests.get(
+                self.url_for(endpoint), headers=headers, params=params
+            )
+            self.check_status(response, 200)
+            return response.json()["results"]
+
         response = requests.get(self.url_for(endpoint), headers=headers, params=params)
         if paginated:
             self.check_status(response, 200)
@@ -76,7 +85,7 @@ class EstelaSimpleClient:
             content = response["results"]
             while next_page:
                 response = requests.get(
-                    self.url_for(endpoint), headers=headers, params=params
+                    next_page, headers=headers
                 )
                 self.check_status(response, 200)
                 response = response.json()
@@ -206,14 +215,14 @@ class EstelaClient(EstelaSimpleClient):
         self.check_status(response, 200)
         return response.json()
 
-    def get_spider_jobs(self, pid, sid):
+    def get_spider_jobs(self, pid, sid, page=None):
         endpoint = "projects/{}/spiders/{}/jobs".format(pid, sid)
-        response = self.get(endpoint, paginated=True)
+        response = self.get(endpoint, paginated=True, page=page)
         return response
 
-    def get_spider_jobs_with_tag(self, pid, sid, tag):
+    def get_spider_jobs_with_tag(self, pid, sid, tag, page=None):
         endpoint = "projects/{}/spiders/{}/jobs?tag={}".format(pid, sid, tag)
-        response = self.get(endpoint, paginated=True)
+        response = self.get(endpoint, paginated=True, page=page)
         return response
 
     def get_spider_job(self, pid, sid, jid):

--- a/estela_cli/list/job.py
+++ b/estela_cli/list/job.py
@@ -21,7 +21,14 @@ SHORT_HELP = "List jobs of a given spider"
     type=click.UNPROCESSED,
     help="Filter jobs by tag",
 )
-def estela_command(sid, pid, tag):
+@click.option(
+    "-p",
+    "--page",
+    default=None,
+    type=int,
+    help="Page number to retrieve (1 = most recent)",
+)
+def estela_command(sid, pid, tag, page):
     """List jobs of a given spider
 
     \b
@@ -48,11 +55,14 @@ def estela_command(sid, pid, tag):
             "The spider does not exist, or you do not have permission to perform this action."
         )
 
-    jobs = []
-    if tag:
-        jobs = estela_client.get_spider_jobs_with_tag(pid, sid, tag)
-    else:
-        jobs = estela_client.get_spider_jobs(pid, sid)
+    try:
+        jobs = []
+        if tag:
+            jobs = estela_client.get_spider_jobs_with_tag(pid, sid, tag, page=page)
+        else:
+            jobs = estela_client.get_spider_jobs(pid, sid, page=page)
+    except Exception:
+        raise click.ClickException("Invalid page number.")
 
     jobs = [
         [


### PR DESCRIPTION
  ## Summary
  - Fix infinite loop in paginated API requests (was requesting the same page forever instead of following next_page URL)
  - Add `--page` option to `list job` command to retrieve a specific page of results
  - Handle invalid page numbers with a clean error message